### PR TITLE
Port to deal with the newer Semigroup dependency

### DIFF
--- a/src/Data/BoolRing.hs
+++ b/src/Data/BoolRing.hs
@@ -68,5 +68,6 @@ instance Ord x ⇒ Free BoolRing x where
 
 newtype BoolRingOr n = BRO { bro :: n }
 
+instance BoolRing r ⇒ Semigroup (BoolRingOr r) where (BRO x) <> (BRO y) = BRO (x ⊕ y ⊕ (x ⊗ y))
 instance BoolRing r ⇒ Monoid (BoolRingOr r) where mempty = BRO r₀ ; mappend (BRO x) (BRO y) = BRO (x ⊕ y ⊕ (x ⊗ y))
 instance BoolRing r ⇒ CMonoid (BoolRingOr r)

--- a/src/Data/CGroup.hs
+++ b/src/Data/CGroup.hs
@@ -19,9 +19,12 @@ instance Ord x ⇒ Free CGroup x where
            emit ((x,n):xs) | n < 0 = cinv (f x) `mappend` emit ((x,n+1):xs)
                            | otherwise = f x `mappend` emit ((x,n-1):xs)
 
+instance Ord x ⇒ Semigroup (FreeA CGroup x) where
+  CG x <> CG y = CG (Map.unionWith (+) x y)
+  
 instance Ord x ⇒ Monoid (FreeA CGroup x) where
   mempty = CG Map.empty
-  CG x `mappend` CG y = CG (Map.unionWith (+) x y)
+  
 
 instance Ord x ⇒ CMonoid (FreeA CGroup x)
 

--- a/src/Data/CMonoid.hs
+++ b/src/Data/CMonoid.hs
@@ -2,6 +2,7 @@
 
 module Data.CMonoid where
 
+import Data.Semigroup
 import Data.Monoid
 import Data.Coproduct.Classes (Free(..))
 import Data.MultiSet
@@ -17,9 +18,13 @@ instance Ord x ⇒ Free CMonoid x where
            emit [x] = f x
            emit (x:xs) = f x `mappend` emit xs 
 
+instance Ord x ⇒ Semigroup (FreeA CMonoid x) where
+  CM x <> CM y = CM (x `union` y)
+  
 instance Ord x ⇒ Monoid (FreeA CMonoid x) where
   mempty = CM empty
-  CM x `mappend` CM y = CM (x `union` y)
+  
+  
 
 instance Ord x ⇒ CMonoid (FreeA CMonoid x) where
 

--- a/src/Data/DLattice.hs
+++ b/src/Data/DLattice.hs
@@ -74,7 +74,9 @@ instance Ord x ⇒ Free DLattice x where
 newtype DLatticeAdd n = DA { da :: n }
 newtype DLatticeMul n = DM { dm :: n }
 
+instance DLattice r ⇒ Semigroup (DLatticeAdd r) where  (DA x) <> (DA y) = DA (x ⊕ y)
 instance DLattice r ⇒ Monoid (DLatticeAdd r) where mempty = DA r₀ ; mappend (DA x) (DA y) = DA (x ⊕ y)
 instance DLattice r ⇒ CMonoid (DLatticeAdd r)
+instance DLattice r ⇒ Semigroup (DLatticeMul r) where (DM x) <> (DM y) = DM (x ⊗ y)
 instance DLattice r ⇒ Monoid (DLatticeMul r) where mempty = DM r₁ ; mappend (DM x) (DM y) = DM (x ⊗ y)
 instance DLattice r ⇒ CMonoid (DLatticeMul r)

--- a/src/Data/Ring.hs
+++ b/src/Data/Ring.hs
@@ -77,8 +77,10 @@ instance Ring Double where (⊕) = (+); (⊗) = (*); rneg = negate; r₀ = 0; r�
 newtype RingAdd n = RA { ra :: n }
 newtype RingMul n = RM { rm :: n }
 
+instance Ring r ⇒ Semigroup (RingAdd r) where (RA x) <> (RA y) = RA (x ⊕ y)
 instance Ring r ⇒ Monoid (RingAdd r) where mempty = RA r₀ ; mappend (RA x) (RA y) = RA (x ⊕ y)
 instance Ring r ⇒ CMonoid (RingAdd r)
+instance Ring r ⇒ Semigroup (RingMul r) where (RM x) <> (RM y) = RM (x ⊗ y)
 instance Ring r ⇒ Monoid (RingMul r) where mempty = RM r₁ ; mappend (RM x) (RM y) = RM (x ⊗ y)
 instance Ring r ⇒ CMonoid (RingMul r)
 

--- a/test/InstanceLifting.hs
+++ b/test/InstanceLifting.hs
@@ -19,27 +19,36 @@ $(deriveLift ''Product)
 -- deriving instance Lift a ⇒ Lift (Sum a)
 -- deriving instance Lift a ⇒ Lift (Product a)
 
+instance {-# OVERLAPS #-} Monoid m ⇒ Semigroup (Code m) where
+   x <> y = [|| $$x `mappend` $$y ||]
+  
 instance {-# OVERLAPS #-} Monoid m ⇒ Monoid (Code m) where
    mempty = [|| mempty ||]
-   x `mappend` y = [|| $$x `mappend` $$y ||] 
+   
+instance {-# OVERLAPS #-} Semigroup (Code String) where
+   x <> y = [|| $$x ++ $$y ||] 
 
 instance {-# OVERLAPS #-} Monoid (Code String) where
    mempty = [|| "" ||]
-   x `mappend` y = [|| $$x ++ $$y ||] 
 
 instance CGroup (Code Int) where
   cinv x = [|| - $$x ||]
 instance CMonoid (Code Int) where
+  
+instance Semigroup (Code Int) where
+  x <> y = [|| $$x + $$y ||]
+
 instance Monoid (Code Int) where
   mempty = [|| 0 ||]
-  mappend x y = [|| $$x + $$y ||]
 
 instance CMonoid (Code Bool) where
 instance CGroup (Code Bool) where
   cinv = id
+instance Semigroup (Code Bool) where
+  x <> y = [|| $$x && $$y ||]
 instance Monoid (Code Bool) where
   mempty = [|| True ||]
-  mappend x y = [|| $$x && $$y ||]
+
 instance BoolRing (Code Bool)
 
 instance Ring (Code Int) where


### PR DESCRIPTION
[Since the docs say:](https://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Monoid.html)
> NOTE: Semigroup is a superclass of Monoid since base-4.11.0.0.