### PR TITLE
Parameterize FreeExt by the type of names.

### DIFF
--- a/src/Data/PartiallyStatic.hs
+++ b/src/Data/PartiallyStatic.hs
@@ -5,27 +5,26 @@ import Data.Coproduct
 import Language.Haskell.TH.Syntax
 import Control.Monad (liftM)
 
--- Variables 
-type Code a = Q (TExp a) -- (for now; more elaborate later)
+newtype Code a = Code { code :: Q (TExp a) }
 
 -- Free extension
-type FreeExt algebra α = Coprod algebra α (FreeA algebra (Code α))
+type FreeExt algebra name α = Coprod algebra α (FreeA algebra (name α))
 
-type FreeExtCon algebra α =
-  Coproduct algebra α (FreeA algebra (Code α))
+type FreeExtCon algebra name α =
+  Coproduct algebra α (FreeA algebra (name α))
 
-sta :: (algebra α, FreeExtCon algebra α) ⇒
-       α → FreeExt algebra α
+sta :: (algebra α, FreeExtCon algebra name α) ⇒
+       α → FreeExt algebra name α
 sta = inl
 
-dyn :: (Free algebra (Code α), FreeExtCon algebra α) ⇒
-       Code α → FreeExt algebra α
+dyn :: (Free algebra (name α), FreeExtCon algebra name α) ⇒
+       name α → FreeExt algebra name α
 dyn = inr . pvar
 
 cd :: (Lift α, Free algebra (Code α), algebra (Code α),
-       FreeExtCon algebra α) ⇒
-      FreeExt algebra α → Code α
+       FreeExtCon algebra Code α) ⇒
+      FreeExt algebra Code α → Code α
 cd = eva tlift (`pbind` id)
 
-tlift :: Lift α ⇒ α → Q (TExp α)
-tlift = liftM TExp . lift
+tlift :: Lift α ⇒ α → Code α
+tlift = Code . liftM TExp . lift

--- a/test/All.hs
+++ b/test/All.hs
@@ -12,21 +12,23 @@ import Data.Coproduct
 import Data.DLattice
 import CodeComparison()
 
-all :: (a → Bool, Code (a → Bool)) → FreeExt Monoid [a] → FreeExt DLattice Bool
-all (f, f') c = dm (eva (DM . inl . g) (DM . inr . h) c)
+all :: (a → Bool, Code (a → Bool)) →
+       FreeExt Monoid Code [a] →
+       FreeExt DLattice Code Bool
+all (f, Code f') c = dm (eva (DM . inl . g) (DM . inr . h) c)
   where g x | Prelude.all f x = r₁
             | otherwise = r₀
-        h = pvar . (`pbind` (\x → [|| Prelude.all $$f' $$x ||]))
+        h = pvar . (`pbind` (\(Code x) → Code [|| Prelude.all $$f' $$x ||]))
 
-any :: (a → Bool, Code (a → Bool)) → FreeExt Monoid [a] → FreeExt DLattice Bool
-any (f, f') c = da (eva (DA . inl . g) (DA . inr . h) c)
+any :: (a → Bool, Code (a → Bool)) → FreeExt Monoid Code [a] → FreeExt DLattice Code Bool
+any (f, Code f') c = da (eva (DA . inl . g) (DA . inr . h) c)
   where g x | Prelude.any f x = r₁
             | otherwise = r₀
-        h = pvar . (`pbind` (\x → [|| Prelude.any $$f' $$x ||]))
+        h = pvar . (`pbind` (\(Code x) → Code [|| Prelude.any $$f' $$x ||]))
 
 
 -- optimized cd for Booleans
-cdBool :: FreeExt DLattice Bool → Code Bool
+cdBool :: FreeExt DLattice Code Bool → Code Bool
 cdBool (DL (NF p)) = cd (cdBool' (map Set.elems (Map.keys (Map.filter (== True) p))))
  where
   cdBool' [] = sta False

--- a/test/CodeComparison.hs
+++ b/test/CodeComparison.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE FlexibleInstances #-}
-
 module CodeComparison where
 
-import Data.PartiallyStatic (Code)
+import Data.PartiallyStatic (Code, code)
 import Control.Monad (liftM)
 import Language.Haskell.TH (runQ, pprint, unType)
 
@@ -15,7 +13,7 @@ import System.IO.Unsafe (unsafePerformIO)
 
 unsafeStringOf :: Code α → String
 unsafeStringOf x = unsafePerformIO $ 
-                   (liftM pprint $ runQ (liftM unType x))
+                   (liftM pprint $ runQ (liftM unType (code x)))
 
 instance Eq (Code α) where x == y = unsafeStringOf x == unsafeStringOf y
 instance Ord (Code α)  where x <= y = unsafeStringOf x <= unsafeStringOf y

--- a/test/InstanceLifting.hs
+++ b/test/InstanceLifting.hs
@@ -20,53 +20,53 @@ $(deriveLift ''Product)
 -- deriving instance Lift a ⇒ Lift (Product a)
 
 instance {-# OVERLAPS #-} Monoid m ⇒ Semigroup (Code m) where
-   x <> y = [|| $$x `mappend` $$y ||]
+   Code x <> Code  y = Code [|| $$x `mappend` $$y ||]
   
 instance {-# OVERLAPS #-} Monoid m ⇒ Monoid (Code m) where
-   mempty = [|| mempty ||]
+   mempty = Code [|| mempty ||]
    
 instance {-# OVERLAPS #-} Semigroup (Code String) where
-   x <> y = [|| $$x ++ $$y ||] 
+   Code x <> Code y = Code [|| $$x ++ $$y ||] 
 
 instance {-# OVERLAPS #-} Monoid (Code String) where
-   mempty = [|| "" ||]
+   mempty = Code [|| "" ||]
 
 instance CGroup (Code Int) where
-  cinv x = [|| - $$x ||]
+  cinv (Code x) = Code [|| - $$x ||]
 instance CMonoid (Code Int) where
   
 instance Semigroup (Code Int) where
-  x <> y = [|| $$x + $$y ||]
+  Code x <> Code y = Code [|| $$x + $$y ||]
 
 instance Monoid (Code Int) where
-  mempty = [|| 0 ||]
+  mempty = Code [|| 0 ||]
 
 instance CMonoid (Code Bool) where
 instance CGroup (Code Bool) where
   cinv = id
 instance Semigroup (Code Bool) where
-  x <> y = [|| $$x && $$y ||]
+  Code x <> Code y = Code [|| $$x && $$y ||]
 instance Monoid (Code Bool) where
-  mempty = [|| True ||]
+  mempty = Code [|| True ||]
 
 instance BoolRing (Code Bool)
 
 instance Ring (Code Int) where
-  x ⊕ y = [|| $$x + $$y ||]
-  x ⊗ y = [|| $$x * $$y ||]
-  rneg x = [|| - $$x ||]
-  r₀ = [|| 0 ||]
-  r₁ = [|| 1 ||]
+  Code x ⊕ Code y = Code [|| $$x + $$y ||]
+  Code x ⊗ Code y = Code [|| $$x * $$y ||]
+  rneg (Code x) = Code [|| - $$x ||]
+  r₀ = Code [|| 0 ||]
+  r₁ = Code [|| 1 ||]
 
 instance Ring (Code Bool) where
-  x ⊕ y = [|| $$x /= $$y ||]
-  x ⊗ y = [|| $$x && $$y ||]
-  rneg x = [|| $$x ||]
-  r₀ = [|| False ||]
-  r₁ = [|| True ||]
+  Code x ⊕ Code y = Code [|| $$x /= $$y ||]
+  Code x ⊗ Code y = Code [|| $$x && $$y ||]
+  rneg (Code x) = Code [|| $$x ||]
+  r₀ = Code [|| False ||]
+  r₁ = Code [|| True ||]
 
 instance DLattice (Code Bool) where
-  x ⊕ y = [|| $$x || $$y ||]
-  x ⊗ y = [|| $$x && $$y ||]
-  r₀ = [|| False ||]
-  r₁ = [|| True ||]
+  Code x ⊕ Code y = Code [|| $$x || $$y ||]
+  Code x ⊗ Code y = Code [|| $$x && $$y ||]
+  r₀ = Code [|| False ||]
+  r₁ = Code [|| True ||]

--- a/test/IsDigit.hs
+++ b/test/IsDigit.hs
@@ -4,6 +4,6 @@ import Data.Coproduct
 import Data.PartiallyStatic
 import qualified Data.Char as Char
 
-isDigit :: FreeExt Set Char → FreeExt Set Bool
+isDigit :: FreeExt Set Code Char → FreeExt Set Code Bool
 isDigit = eva (sta . Char.isDigit)
-              ((\(F x) → dyn [|| Char.isDigit $$x ||]))
+              ((\(F (Code x)) → dyn (Code [|| Char.isDigit $$x ||])))

--- a/test/LinAlg.hs
+++ b/test/LinAlg.hs
@@ -10,7 +10,7 @@ import qualified Data.Map as Map
 import qualified Data.MultiSet as MultiSet
 import Language.Haskell.TH.Syntax (Lift)
 
-type PsIntRing = FreeExt Ring Int
+type PsIntRing = FreeExt Ring Code Int
 
 dot :: Ring r ⇒ [r] → [r] → r
 dot xs ys = sumr (zipWith (⊗) xs ys)
@@ -18,28 +18,28 @@ dot xs ys = sumr (zipWith (⊗) xs ys)
 sumr :: Ring r ⇒ [r] → r
 sumr = foldr (⊕) r₀
 
-cdNumRing :: (Num n, Eq n, Ring (Code n), Lift n) ⇒ FreeExt Ring n → Code n
+cdNumRing :: (Num n, Eq n, Ring (Code n), Lift n) ⇒ FreeExt Ring Code n → Code n
 cdNumRing (CR (MN m)) = cd $ sumBits $ Map.assocs m
  where
   sumBits = foldr (\(xs, c) r → (prodVars xs `prod2` sta c) `sum2` r) (sta 0)
   prodVars = prodN . map dyn . MultiSet.elems
 
 -- TODO: we could simplify further here, reducing the number of multiplications as for 'power'
-prodN :: (Num n, Eq n, Lift n) ⇒ [FreeExt Set n] → FreeExt Set n
+prodN :: (Num n, Eq n, Lift n) ⇒ [FreeExt Set Code n] → FreeExt Set Code n
 prodN = foldr prod2 (sta 1)
 
-sum2 :: (Num n, Eq n, Lift n) ⇒ FreeExt Set n → FreeExt Set n → FreeExt Set n
+sum2 :: (Num n, Eq n, Lift n) ⇒ FreeExt Set Code n → FreeExt Set Code n → FreeExt Set Code n
 sum2 (Inl 0) r = r
 sum2 l (Inl 0) = l
 sum2 (Inl l) (Inl r) = sta (l + r)
-sum2 l r = dyn [|| $$(cd l) + $$(cd r) ||]
+sum2 l r = dyn (Code [|| $$(code (cd l)) + $$(code (cd r)) ||])
 
-prod2 :: (Num n, Eq n, Lift n) ⇒ FreeExt Set n → FreeExt Set n → FreeExt Set n
+prod2 :: (Num n, Eq n, Lift n) ⇒ FreeExt Set Code n → FreeExt Set Code n → FreeExt Set Code n
 prod2 _ (Inl 0) = sta 0
 prod2 (Inl 0) _ = sta 0
 prod2 x (Inl 1) = x
 prod2 (Inl 1) y = y
-prod2 l r = dyn [|| $$(cd l) * $$(cd r) ||]
+prod2 l r = dyn (Code [|| $$(code (cd l)) * $$(code (cd r)) ||])
 
 
 -- matrix-matrix multiplication

--- a/test/Power.hs
+++ b/test/Power.hs
@@ -20,29 +20,32 @@ deriving instance Enum n ⇒ Enum (Product n)
 -- A destructor that does better than the default.
 -- (Could we make this the default?  'eva' doesn't know about
 --  code and 'PartiallyStatic.cd' doesn't know about CMonoid).
-cdPower :: FreeExt CMonoid (Product Int) -> Code Int
-cdPower (C 0 (CM r)) = [|| 0 ||]
-cdPower (C 1 (CM r)) = powerVn (toOccurList r) (\x -> [|| getProduct $$x ||])
-cdPower (C l (CM r)) = powerVn (toOccurList r) (\x -> [|| getProduct (l * $$x) ||])
+cdPower :: FreeExt CMonoid Code (Product Int) -> Code Int
+cdPower (C 0 (CM r)) = Code [|| 0 ||]
+cdPower (C 1 (CM r)) = powerVn (toOccurList r)
+                       (\(Code x) -> Code [|| getProduct $$x ||])
+cdPower (C l (CM r)) = powerVn (toOccurList r)
+                       (\(Code x) -> Code [|| getProduct (l * $$x) ||])
 
 
 -- reducing multiplications for one variable
 powerV1 :: (Integral a, Lift a) => Int -> Code a -> (Code a -> Code b) -> Code b
-powerV1 0 x k = k [|| 1 ||]
+powerV1 0 x k = k (Code [|| 1 ||])
 powerV1 1 x k = k x
-powerV1 n x k | even n = [|| let y = $$x * $$x in
-                            $$(powerV1 (n `div` 2) [||y||] k) ||]
-             | otherwise = [|| let y = $$x * $$x in
-                            $$(powerV1 ((n - 1) `div` 2) [||y||]
-                              (\z -> k [|| $$x * $$z ||]))||]
+powerV1 n (Code x) k | even n = Code [|| let y = $$x * $$x in
+                                         $$(code (powerV1 (n `div` 2) (Code [||y||]) k)) ||]
+                     | otherwise = Code [|| let y = $$x * $$x in
+                                            $$(code (powerV1 ((n - 1) `div` 2) (Code [||y||])
+                                               (\(Code z) ->
+                                                   k (Code [|| $$x * $$z ||]))))||]
 
 -- reducing multiplications for multiple variables
 powerVn :: (Integral a, Lift a) => [(Code a, Int)] -> (Code a -> Code b) -> Code b
-powerVn [] k = k [|| 1 ||]
+powerVn [] k = k (Code [|| 1 ||])
 powerVn [(x, n)] k = powerV1 n x k
-powerVn ((x,n):xs) k = powerV1 n x $ \y ->
-                       powerVn xs $ \z ->
-                       k [|| $$y * $$z ||]
+powerVn ((x,n):xs) k = powerV1 n x $ \(Code y) ->
+                       powerVn xs $ \(Code z) ->
+                       k (Code [|| $$y * $$z ||])
 
 -- the example code itself
 power :: CMonoid i ⇒ i → Int → i

--- a/test/Printf.hs
+++ b/test/Printf.hs
@@ -35,33 +35,33 @@ newtype FmtS r a = FmtS {fmtS :: (Code String → r) → (Code String → a)}
 
 instance Format FmtS where
   type Acc FmtS α = Code α
-  lit x = FmtS $ \k s → k [|| $$s ++ x ||]
+  lit x = FmtS $ \k (Code s) → k (Code [|| $$s ++ x ||])
   f `cat` g = FmtS (fmtS f . fmtS g)
-  int = FmtS $ \k s x → k [|| $$s ++ show $$x ||]
-  str = FmtS $ \k s x → k [|| $$s ++ $$x ||]
-  sprintf p = fmtS p id [|| "" ||]
+  int = FmtS $ \k (Code s) (Code x) → k (Code [|| $$s ++ show $$x ||])
+  str = FmtS $ \k (Code s) (Code x) → k (Code [|| $$s ++ $$x ||])
+  sprintf p = fmtS p id (Code [|| "" ||])
 
 -- partially-static printf
-newtype FmtPS r a = FmtPS { fmtPS :: (FreeExt Monoid String → r) →
-                                     (FreeExt Monoid String → a) }
+newtype FmtPS r a = FmtPS { fmtPS :: (FreeExt Monoid Code String → r) →
+                                     (FreeExt Monoid Code String → a) }
 
 instance Format FmtPS where
   type Acc FmtPS α = Code α
   lit x = FmtPS $ \k s → k (s `mappend` sta x)
   f `cat` g = FmtPS (fmtPS f . fmtPS g)
-  int = FmtPS $ \k s x → k (s `mappend` dyn [|| show $$x ||])
+  int = FmtPS $ \k s (Code x) → k (s `mappend` dyn (Code [|| show $$x ||]))
   str = FmtPS $ \k s x → k (s `mappend` dyn x)
   sprintf (FmtPS p) = p cd mempty
 
 -- partially-static printf with n-ary destructor function
-newtype FmtPS2 r a = FmtPS2 { fmtPS2 :: (FreeExt Monoid String → r) →
-                                        (FreeExt Monoid String → a) }
+newtype FmtPS2 r a = FmtPS2 { fmtPS2 :: (FreeExt Monoid Code String → r) →
+                                        (FreeExt Monoid Code String → a) }
 
 instance Format FmtPS2 where
   type Acc FmtPS2 α = Code α
   lit x = FmtPS2 $ \k s → k (s `mappend` sta x)
   f `cat` g = FmtPS2 (fmtPS2 f . fmtPS2 g)
-  int = FmtPS2 $ \k s x → k (s `mappend` dyn [|| show $$x ||])
+  int = FmtPS2 $ \k s (Code x) → k (s `mappend` dyn (Code [|| show $$x ||]))
   str = FmtPS2 $ \k s x → k (s `mappend` dyn x)
   sprintf (FmtPS2 p) = p cdStrings mempty
 
@@ -72,26 +72,26 @@ unstagedExample :: Int → Int → String
 unstagedExample = sprintf (exampleFmt :: Fmt _ _)
 
 stagedCode :: Code (Int → Int → String)
-stagedCode = [|| \x y → $$(sprintf (exampleFmt :: FmtS _ _) [||x||] [||y||]) ||]
+stagedCode = Code [|| \x y → $$(code (sprintf (exampleFmt :: FmtS _ _) (Code [||x||]) (Code [||y||]))) ||]
 
 psCode :: Code (Int → Int → String)
-psCode = [|| \x y → $$(sprintf (exampleFmt :: FmtPS _ _) [||x||] [||y||]) ||]
+psCode = Code [|| \x y → $$(code (sprintf (exampleFmt :: FmtPS _ _) (Code [||x||]) (Code [||y||]))) ||]
 
 -- a destructor for strings that generates a single n-ary concatenation
-cdStrings :: FreeExt Monoid String -> Code String
-cdStrings m = [|| Prelude.concat $$(liftList (eva g h m)) ||]
+cdStrings :: FreeExt Monoid Code String -> Code String
+cdStrings m = Code [|| Prelude.concat $$(code (liftList (eva g h m))) ||]
   where g "" = []
-        g s = [[||s||]]
+        g s = [Code [||s||]]
         h (P s) = s
 
 liftList :: [Code a] -> Code [a]
-liftList [] = [||[]||]
-liftList (x:xs) = [||$$x : $$(liftList xs)||]
+liftList [] = Code [||[]||]
+liftList (Code x:xs) = Code [||$$x : $$(code (liftList xs))||]
 
 sprintfN (FmtPS p) = p cdStrings mempty
 
 psCodeN :: Code (Int → Int → String)
-psCodeN = [|| \x y → $$(sprintfN exampleFmt [||x||] [||y||]) ||]
+psCodeN = Code [|| \x y → $$(code (sprintfN exampleFmt (Code [||x||]) (Code [||y||]))) ||]
 
 benchFmt :: Format f => f c (Acc f String
                           -> Acc f String

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -18,10 +18,10 @@ import qualified Datatypes
 import qualified IsDigit
 import Datatypes (PSIList1 (..), cons2, nil2, dyn2, cons2', nil2', cons3, nil3, cons3', nil3', dyn3)
 
-showCode ::  Q (TExp a) → IO String
-showCode c = do e ← runQ (liftM unType c) ; return $ pprint e
+showCode ::  Code a → IO String
+showCode (Code c) = do e ← runQ (liftM unType c) ; return $ pprint e
 
-printCode :: String -> Q (TExp a) → IO ()
+printCode :: String -> Code a → IO ()
 printCode description c = do
   e ← showCode c
   putStrLn $ "  " ++ description ++ "\n"
@@ -73,15 +73,15 @@ main = do
   assertEqual (Power.power 3 7 :: Product Int) 2187
 
   printCode "Naive staging (7 multiplications)"
-    (Power.power ([|| 3 ||] :: Q (TExp Int)) 7 )
+    (Power.power (Code [|| 3 ||] :: Code Int) 7 )
 
   printCode "Staging with partially-static data (4 multiplications)"
-    (Power.cdPower (Power.power (dyn [|| Product 3 ||]) 7))
+    (Power.cdPower (Power.power (dyn (Code [|| Product 3 ||])) 7))
 
   printCode "combining separated calls to 'power' (4 multiplications)"
-    ([|| \x' y' ->
-         $$(let x = dyn [||x'||] ; y = dyn [||y'||] in
-            Power.cdPower
+    (Code [|| \x' y' ->
+         $$(let x = dyn (Code [||x'||]) ; y = dyn (Code [||y'||]) in
+            code $ Power.cdPower
              (Power.power x 3 `mappend` y `mappend` Power.power x 3)) ||])
 
 
@@ -92,10 +92,10 @@ main = do
   startSection "Inner product"
 
   printCode "Staging with partially-static data"
-    ([|| \y₁ y₂ y₃ → 
+    (Code [|| \y₁ y₂ y₃ → 
          $$(let v₁ = [sta 0,         sta 3       , sta 1        ]
-                v₂ = [dyn [||y₁||] , dyn [||y₂||], dyn [||y₃||] ]
-             in LinAlg.cdNumRing $ (LinAlg.dot v₁ v₂ :: FreeExt Ring Int)) ||])
+                v₂ = [dyn (Code [||y₁||]) , dyn (Code [||y₂||]), dyn (Code [||y₃||]) ]
+             in code $ LinAlg.cdNumRing $ (LinAlg.dot v₁ v₂ :: FreeExt Ring Code Int)) ||])
 
   endSection
 
@@ -104,29 +104,29 @@ main = do
   startSection "All and any"
 
   printCode "Staging 'all' with partially-static data"
-    ([|| \x →
-         $$(All.cdBool (All.all (even, [||even||])
-                (sta [2,4] `mappend` dyn [||x||] `mappend` sta [3]))) ||])
+    (Code [|| \x →
+         $$(code $ All.cdBool (All.all (even, Code [||even||])
+                (sta [2,4] `mappend` dyn (Code [||x||]) `mappend` sta [3]))) ||])
 
   printCode "Staging 'all' with more partially-static data"
-    ([|| \x →
-         $$(All.cdBool (All.all (even, [||even||])
-                (sta [2,4] `mappend` dyn [||x||] `mappend` sta [2]))) ||])
+    (Code [|| \x →
+         $$(code $ All.cdBool (All.all (even, Code [||even||])
+                (sta [2,4] `mappend` dyn (Code [||x||]) `mappend` sta [2]))) ||])
 
   printCode "Staging 'any' with partially-static data (1)"
-    ([|| \x →
-         $$(All.cdBool (All.any (even, [||even||])
-                (sta [2,4] `mappend` dyn [||x||] `mappend` sta [3]))) ||])
+    (Code [|| \x →
+         $$(code $ All.cdBool (All.any (even, Code [||even||])
+                (sta [2,4] `mappend` dyn (Code [||x||]) `mappend` sta [3]))) ||])
 
   printCode "Staging 'any' with partially-static data (2)"
-    ([|| \x →
-         $$(All.cdBool (All.any (even, [||even||])
-                (sta [1,3] `mappend` dyn [||x||] `mappend` sta [2] `mappend` dyn [||x||]))) ||])
+    (Code [|| \x →
+         $$(code $ All.cdBool (All.any (even, Code [||even||])
+                (sta [1,3] `mappend` dyn (Code [||x||]) `mappend` sta [2] `mappend` dyn (Code [||x||])))) ||])
 
   printCode "Staging 'any' with partially-static data (3)"
-    ([|| \x →
-         $$(All.cdBool (All.any (even, [||even||])
-                (sta [1,3] `mappend` dyn [||x||] `mappend` sta [3]))) ||])
+    (Code [|| \x →
+         $$(code $ All.cdBool (All.any (even, Code [||even||])
+                (sta [1,3] `mappend` dyn (Code [||x||]) `mappend` sta [3]))) ||])
 
   endSection
 
@@ -138,22 +138,22 @@ main = do
     (cd (IsDigit.isDigit (sta '3')))
 
   printCode "IsDigit with a dynamic argument"
-    [|| \x -> $$(cd (IsDigit.isDigit (dyn [||x||]))) ||]
+    (Code [|| \x -> $$(code $ cd (IsDigit.isDigit (dyn (Code [||x||])))) ||])
 
   endSection
 
 
   startSection "Partially-static algebraic datatypes"
 
-  let psList1 = 1 `Cons1` 2 `Cons1` 3 `Cons1` Dyn1 [|| [4, 5, 6] ||]
+  let psList1 = 1 `Cons1` 2 `Cons1` 3 `Cons1` Dyn1 (Code [|| [4, 5, 6] ||])
   printCode "Staging with partially-static data (concrete)"
     (cd (Datatypes.sum1 psList1))
 
-  let psList2 = 1 `cons2` 2 `cons2` 3 `cons2` dyn2 [|| 4 `cons2'` 5 `cons2'` 6 `cons2'` nil2' ||]
+  let psList2 = 1 `cons2` 2 `cons2` 3 `cons2` dyn2 (Code [|| 4 `cons2'` 5 `cons2'` 6 `cons2'` nil2' ||])
   printCode "Staging with partially-static data (open-recursive / F-algebra)"
     (cd (Datatypes.sum2 psList2))
 
-  let psList3 = 1 `cons3` 2 `cons3` 3 `cons3` dyn3 [|| 4 `cons3'` 5 `cons3'` 6 `cons3'` nil3' ||]
+  let psList3 = 1 `cons3` 2 `cons3` 3 `cons3` dyn3 (Code [|| 4 `cons3'` 5 `cons3'` 6 `cons3'` nil3' ||])
   printCode "Staging with partially-static data (coproducts)"
     (cd (Datatypes.sum3 psList3))
   


### PR DESCRIPTION
This allows us to use name types other than `Code`.

`Code` is now a newtype, so that it can be used to instantiate `FreeExt`.

For the moment, the tests still use `Code` for names throughout, which involves some extra boilerplate.  But I think things'll become simpler again when we can use some proposals that have recently been adopted in GHC:

*  Make Q (TExp a) into a newtype
   https://github.com/ghc-proposals/ghc-proposals/pull/195

*  Overloaded Quotation Brackets
   https://github.com/ghc-proposals/ghc-proposals/pull/246